### PR TITLE
Add working link to mirror of pandocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Special thanks to
 -----------------
 
 * http://imrannazar.com/GameBoy-Emulation-in-JavaScript:-The-CPU
-* http://nocash.emubase.de/pandocs.htm
+* http://nocash.emubase.de/pandocs.htm (Available at http://bgb.bircd.org/pandocs.htm)
 * https://github.com/alexcrichton/jba (The Rust branch)


### PR DESCRIPTION
Add working link to mirror of pandocs, as the one in README (nocache.emubase.de) appears to be dead

(Used this alternative for quite some time whilst developing another gameboy emulator and they produced BGB, so a fair resource to link to, I think)