### PR TITLE
Fix the waveram being half-empty

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -287,8 +287,8 @@ impl WaveChannel {
                 }
             },
             0xFF30 ..= 0xFF3F => {
-                self.waveram[(a as usize - 0xFF30) / 2] = v >> 4;
-                self.waveram[(a as usize - 0xFF30) / 2 + 1] = v & 0xF;
+                self.waveram[(a as usize - 0xFF30) * 2] = v >> 4;
+                self.waveram[(a as usize - 0xFF30) * 2 + 1] = v & 0xF;
             },
             _ => (),
         }


### PR DESCRIPTION
The logic to unpack 8 bit values into 4 bit samples should be reversed
compared to when it's read.