### PR TITLE
Add missing LYC=LY interrupt check

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -285,7 +285,10 @@ impl GPU {
             0xFF42 => self.scy = v,
             0xFF43 => self.scx = v,
             0xFF44 => {}, // Read-only
-            0xFF45 => self.lyc = v,
+            0xFF45 => {
+                self.lyc = v;
+                self.check_interrupt_lyc();
+            },
             0xFF46 => panic!("0xFF46 should be handled by MMU"),
             0xFF47 => { self.palbr = v; self.update_pal(); },
             0xFF48 => { self.pal0r = v; self.update_pal(); },


### PR DESCRIPTION
## Tl;dr

Add missing LYC=LY interrupt check when LYC register is set. Fixes vibrations due to pallette chanes hooked to LYC interrupt in Donkey Kong demo animations (and maybe some other roms).

### Details

In [Donkey Kong](https://www.emulatorgames.net/download/?rom=donkey-kong-ju-v11) when no keys are pressed the intro screen is followed by demo animations (eg mario gym sequence). This is drawing the screen with timed palette changes mapped to LYC (00 / 01 / 67). LYC is however set when LY is already at that value.

I'm not 100% sure, however I suspect LYC set needs to include an interrupt check. It also enforces my hunch that this emulator has passes the popular cpu instruction and instruction timing tests - so I assume the error is not in timing but the set of LYC.