### PR TITLE
Update timer.rs - clock ticks from timer

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,7 +16,7 @@ impl Timer {
             counter: 0,
             modulo: 0,
             enabled: false,
-            step: 256,
+            step: 1024, //256 * 4
             internalcnt: 0,
             internaldiv: 0,
             interrupt: 0,
@@ -31,7 +31,7 @@ impl Timer {
             0xFF07 => {
                 0xF8 |
                 (if self.enabled { 0x4 } else { 0 }) |
-                (match self.step { 16 => 1, 64 => 2, 256 => 3, _ => 0 })
+                (match self.step {  16 => 1, 64 => 2, 256 => 3, _ => 0 }) //4*4, 16*4, 64*4, 256*4
             }
             _ => panic!("Timer does not handler read {:4X}", a),
         }
@@ -52,9 +52,9 @@ impl Timer {
 
     pub fn do_cycle(&mut self, ticks: u32) {
         self.internaldiv += ticks;
-        while self.internaldiv >= 256 {
+        while self.internaldiv >= 1024 { //256*4
             self.divider = self.divider.wrapping_add(1);
-            self.internaldiv -= 256;
+            self.internaldiv -= 1024;
         }
 
         if self.enabled {


### PR DESCRIPTION
On the CPU function do_cycles, you give the the mmu.do_cycles clock ticks (machine cycles * 4), the the timer received clock ticks but use machine cycles. example:
div increase each 256 m cycles but you need to convert it as clock ticks because you gave to the function clock ticks from instruction
same for TIMA clock