### PR TITLE
fix default value of tac speed

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,7 +16,7 @@ impl Timer {
             counter: 0,
             modulo: 0,
             enabled: false,
-            step: 256,
+            step: 1024,
             internalcnt: 0,
             internaldiv: 0,
             interrupt: 0,


### PR DESCRIPTION
Ok, I made the change for tac speed default value at the powerup sequence from 256 to 1024.

You can accept this pull request and delete the old one.