### PR TITLE
Adds pure-rust blip_buf as a feature

### DIFF
--- a/librboy/Cargo.toml
+++ b/librboy/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "librboy"
 version = "0.2.0"
-authors = [ "mvdnes <git@mathijs.vd-nes.nl>" ]
+authors = ["mvdnes <git@mathijs.vd-nes.nl>"]
 edition = "2018"
 
 [dependencies]
-blip_buf = ">=0.1.3"
+blip_buf = { version = ">=0.1.3", optional = true }
+blip_buf_rust = { git = "https://github.com/greenfox1505/blip_buf-rs", branch = "rust_impl", optional = true, package = "blip_buf" }
+
+[features]
+default = ["libc"]
+libc = ["dep:blip_buf"]
+rust = ["dep:blip_buf_rust"]

--- a/librboy/src/sound.rs
+++ b/librboy/src/sound.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "libc")]
 use blip_buf::BlipBuf;
+#[cfg(feature = "rust")]
+use blip_buf_rust::BlipBuf;
 
 const WAVE_PATTERN : [[i32; 8]; 4] = [[-1,-1,-1,-1,1,-1,-1,-1],[-1,-1,-1,-1,1,1,-1,-1],[-1,-1,1,1,1,1,-1,-1],[1,1,1,1,-1,-1,1,1]];
 const CLOCKS_PER_SECOND : u32 = 1 << 22;


### PR DESCRIPTION
When/if the BlipBuf gets merged in, I'll redirect the `git = "...` to the main repo.