### PR TITLE
Make SerialCallback public and removes trait requirements.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 pub use crate::gpu::{SCREEN_H, SCREEN_W};
 pub use crate::keypad::KeypadKey;
 pub use crate::sound::AudioPlayer;
+pub use crate::serial::SerialCallback;
 
 pub mod device;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub trait SerialCallback {
+pub trait SerialCallback: Send {
     fn call(&mut self, value: u8) -> Option<u8>;
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub trait SerialCallback: Send + Sync {
+pub trait SerialCallback {
     fn call(&mut self, value: u8) -> Option<u8>;
 }
 


### PR DESCRIPTION
`SerialCallback` needs to be public to be accessible outside of rboy.

`SerialCallback` didn't need `Send + Sync` to function. Having it caused issues with my implementation.

I'm not sure the serial connection is fully implemented, in the opcode side. I'm using some GBStudio Link cable implementation, but it seems like the game hangs (running, waiting for a packet, animations continuing, but not progressing) when a link cable call begins. It's possible GBStudio isn't fully implemented, but people have gotten link cable messaging working before. I've tried running as a "host" and running as a "client", but I don't get any message as a host and client sends a single "2" and then hang (animating, but not progressing).

