### PR TITLE
Implement PCM12 and PCM34 registers

### DIFF
--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -235,7 +235,7 @@ impl MMU {
             0xFF70 => self.wrambank as u8,
             0xFF72..=0xFF73 => self.undocumented_cgb_regs[address as usize - 0xFF72],
             0xFF75 => self.undocumented_cgb_regs[2] | 0b10001111,
-            0xFF76..=0xFF77 => 0x00, // CGB PCM registers. Not yet implemented.
+            0xFF76..=0xFF77 => self.sound.as_mut().unwrap().rb(address),
             0xFF80..=0xFFFE => self.zram[address as usize & 0x007F],
             0xFFFF => self.inte,
             _ => 0xFF,

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -721,7 +721,7 @@ impl Sound {
 
     pub fn rb(&mut self, a: u16) -> u8 {
         self.run();
-        let v = match a {
+        match a {
             0xFF10..=0xFF14 => self.channel1.rb(a),
             0xFF16..=0xFF19 => self.channel2.rb(a),
             0xFF1A..=0xFF1E => self.channel3.rb(a),
@@ -737,9 +737,12 @@ impl Sound {
                     | if self.channel1.on() { 0x1 } else { 0x0 })
             }
             0xFF30..=0xFF3F => self.channel3.rb(a),
+            0xFF76 => (((self.channel1.last_amp as u32 & 0xF0000000) | 
+                (self.channel2.last_amp as u32 & 0xF0000000) >> 4) >> 28) as u8,
+            0xFF77 => (((self.channel3.last_amp as u32 & 0xF0000000) |
+                (self.channel4.last_amp as u32 & 0xF0000000) >> 4) >> 28) as u8,
             _ => 0xFF,
-        };
-        return v;
+        }
     }
 
     pub fn wb(&mut self, a: u16, v: u8) {


### PR DESCRIPTION
This PR (supposedly) implements the undocumented PCM12 and PCM34 GBC registers that allow reading the current sound amplitudes.

TODO:

- #41 needs fixing in order to test this with GBVisuaizer
- I think this probably needs to return `0x00` on DMG and other non CGB models.