### PR TITLE
Move the --audio and --test-mode flags to features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ typetag = "0.2.20"
 ciborium = "0.2.2"
 
 [features]
-gui = [ "clap", "cpal", "glium", "winit" ]
-audio = []
+gui = [ "clap", "glium", "winit" ]
+audio = [ "cpal" ]
 test = []
 
 [[bin]]
 name = "rboy"
 test = false
 doc = false
-required-features = [ "gui" ]
+required-features = [ "gui", "audio" ]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ ciborium = "0.2.2"
 
 [features]
 gui = [ "clap", "cpal", "glium", "winit" ]
+audio = []
+test = []
 
 [[bin]]
 name = "rboy"


### PR DESCRIPTION
If audio is ready for prime time, the feature ought to be built in by default. Test mode should be a special build in any event.