### PR TITLE
read/write byte/wide externally

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2533,6 +2533,20 @@ impl CPU {
         let n = self.fetchbyte() as i8;
         self.reg.pc = ((self.reg.pc as u32 as i32) + (n as i32)) as u16;
     }
+    
+    pub fn read_byte(&mut self, address: u16) -> u8 {
+        self.mmu.rb(address)
+    }
+    pub fn write_byte(&mut self, address: u16, byte:u8) {
+        self.mmu.wb(address,byte)
+    }
+    
+    pub fn read_wide(&mut self, address: u16) -> u16 {
+        self.mmu.rw(address)
+    }
+    pub fn write_wide(&mut self, address: u16, wide:u16) {
+        self.mmu.ww(address,wide)
+    }
 }
 
 #[cfg(test)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -180,4 +180,17 @@ impl Device {
     pub fn check_and_reset_ram_updated(&mut self) -> bool {
         self.cpu.mmu.mbc.check_and_reset_ram_updated()
     }
+
+    pub fn read_byte(&mut self,address:u16) -> u8 {
+        self.cpu.read_byte(address)
+    }
+    pub fn write_byte(&mut self,address:u16,byte:u8) {
+        self.cpu.write_byte(address,byte)
+    }
+    pub fn read_wide(&mut self,address:u16) -> u16 {
+        self.cpu.read_wide(address)
+    }
+    pub fn write_wide(&mut self,address:u16,byte:u16) {
+        self.cpu.write_wide(address,byte)
+    }
 }


### PR DESCRIPTION
Adds the ability to read/write a byte/wide from an address. This is intended for debugging and communication between the internal ROM and the host emulator.